### PR TITLE
Add trailing slashes when using the @url directive

### DIFF
--- a/src/Blade.php
+++ b/src/Blade.php
@@ -59,7 +59,7 @@ class Blade
         $this->bladeCompiler->directive('url', function ($expression) {
             $expression = substr($expression, 1, - 1);
 
-            return "<?php echo str_replace('//', '/', \$base_url.'/'.trim($expression, '/'));  ?>";
+            return "<?php echo str_replace('//', '/', \$base_url.'/'.trim($expression, '/').'/');  ?>";
         });
     }
 }

--- a/src/Blade.php
+++ b/src/Blade.php
@@ -59,7 +59,7 @@ class Blade
         $this->bladeCompiler->directive('url', function ($expression) {
             $expression = substr($expression, 1, - 1);
 
-            return "<?php echo str_replace('//', '/', \$base_url.'/'.trim($expression, '/').'/');  ?>";
+            return "<?php echo str_replace(array('///', '//'), '/', \$base_url.'/'.trim($expression, '/').'/');  ?>";
         });
     }
 }


### PR DESCRIPTION
Since the site is static and all URLs map to static directories, Apache and IIS (not sure on nginx) redirect non-trailing slash URLs to trailing slash. This means that every link via @url will currently trigger a 301 redirect.

This removes the redirect by having all URLs in the "trailing slash" format
