### PR TITLE
Enable command php katana post

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,13 @@ The complete Katana documentation can be found here: http://themsaid.github.io/k
 ## Blog generator
 
 Katana is shipped with a static blog generator, all you need to do is create a new `.blade.php` file in the `/content/_blog` directory and Katana
-will compile all the posts and present them in a view of your choice.
+will compile all the posts and present them in a view of your choice or you can run in terminal for create the file automatically.
+
+```
+php katana post "Title of the post"
+```
+
+If you prefer create a Markdown file, add `--m` in the end of the command.
 
 Blog posts list is paginated based on the configuration options in `config.php`. There's also a `$blogPosts` variable available in all your blade
 views that contains an array of posts.

--- a/src/Commands/PostCommand.php
+++ b/src/Commands/PostCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Katana\Commands;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Command\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Factory;
+use Katana\PostBuilder;
+
+class PostCommand extends Command
+{
+    /**
+     * The FileSystem instance.
+     *
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * The FileSystem instance.
+     *
+     * @var Factory
+     */
+    private $viewFactory;
+
+    /**
+     * PostCommand constructor.
+     *
+     * @param Factory $viewFactory
+     * @param Filesystem $filesystem
+     */
+    public function __construct(Factory $viewFactory, Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+
+        $this->viewFactory = $viewFactory;
+
+        parent::__construct();
+    }
+
+    /**
+     * Configure the command.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->setName('post')
+            ->setDescription('Generate a blog post.')
+            ->addArgument('title', InputArgument::OPTIONAL, 'The Post Tilte', 'My New Post')
+            ->addOption('m', null, InputOption::VALUE_NONE, 'Create a Markdown template file');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {	
+    	$post = new PostBuilder(
+            $this->filesystem,
+            $input->getArgument('title'),
+            $input->getOption('m')
+        );
+
+        $post->build();
+
+        $output->writeln(
+
+            sprintf("<info>Post \"%s\" was generated successfully.</info>", $input->getArgument('title'))
+        );
+    }
+}

--- a/src/Katana.php
+++ b/src/Katana.php
@@ -10,6 +10,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\FileViewFinder;
 use Illuminate\Events\Dispatcher;
 use Katana\Commands\BuildCommand;
+use Katana\Commands\PostCommand;
 use Illuminate\View\Factory;
 
 class Katana
@@ -71,7 +72,8 @@ class Katana
     private function registerCommands()
     {
         $this->application->addCommands([
-            new BuildCommand($this->viewFactory, $this->filesystem)
+            new BuildCommand($this->viewFactory, $this->filesystem),
+            new PostCommand($this->viewFactory, $this->filesystem)
         ]);
     }
 

--- a/src/PostBuilder.php
+++ b/src/PostBuilder.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Katana;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\SplFileInfo;
+use Katana\FileHandlers\BlogPostHandler;
+use Illuminate\Filesystem\Filesystem;
+use Katana\FileHandlers\BaseHandler;
+use Illuminate\View\Factory;
+use Illuminate\Support\Str;
+
+class PostBuilder
+{   
+    /**
+     * The title instance.
+     *
+     * @var Filesystem
+     */
+    private $title;
+
+    /**
+     * The template instance.
+     *
+     * @var Filesystem
+     */
+    private $template;
+
+    /**
+     * The FileSystem instance.
+     *
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * PostBuilder constructor.
+     *
+     * @param Filesystem $filesystem
+     * @param string $environment
+     */
+    public function __construct(Filesystem $filesystem, string $title, string $template = null)
+    {
+        $this->filesystem = $filesystem;
+
+        $this->title = $title;
+
+        $this->template = $template;
+    }
+
+    /**
+     * Build the template view post.
+     *
+     * @return void
+     */
+    public function build()
+    {
+        $this->filesystem->put(
+
+            sprintf('/%s/_blog/%s', KATANA_CONTENT_DIR, $this->nameFile()),
+
+            $this->buildTemplate()
+
+        );
+    }
+
+    /**
+     * Return the default template of the new post
+     *
+     * @return string  
+     */
+    public function buildTemplate()
+    {   
+        return ($this->template)?
+           "---
+            \rview::extends: _includes.blog_post_base
+            \rview::yields: post_body
+            \rpageTitle: ".$this->title."
+            \rpost::title: ".$this->title."
+            \rpost::date: ".date('F d, Y')."
+            \rpost::brief: Write the description of the post here!
+            \r---
+            
+            \rWrite your post content here!":
+
+           "@extends('_includes.blog_post_base')
+            \r@section('post::title', '".$this->title."')
+            \r@section('post::date', '".date('F d, Y')."')
+            \r@section('post::brief', 'Write the description of the post here!')
+            \r@section('pageTitle')- @yield('post::title')@stop
+            \r@section('post_body')
+                \r\t@markdown
+                    \r\t\tWrite your the content of the post here!
+                \r\t@endmarkdown
+            \r@stop";
+    }
+
+    /**
+     * Return the name file of the post
+     *
+     * @return string
+     */
+    public function nameFile()
+    {   
+        $slug = strtolower(trim($this->title));
+
+        $slug = preg_replace('/[^a-z0-9-]/', '-', $slug);
+
+        $slug = preg_replace('/-+/', "-", $slug);
+
+        $extension = ($this->template)? "md": "blade.php";
+
+        return sprintf('%s-%s-.%s', date('Y-m-d'), $slug, $extension);
+    }
+
+}


### PR DESCRIPTION
In the archive Katana.php was inserted into registerCommands method,
one call for the PostCommand Class that set parameter of the command
inserted through terminal.

The PostCommand Class does one call of the PostBuilder class and send
feedback for user. In PostBuilder the name file for new Post is defined
through method nameFile, where the date, the slug of the title and the
blade extension or markdown extension are concatenated. the file is save
on /content/_blog

Now we can create a post through terminal, only running

```
php katana post "Title of the my post"
```

This will be create a blade file like `F-d-Y-title-of-the-my-post.blade.php` in /content/_blog/. The title is `optional` case you don't inform the title, will be created one file with title "My new Post".

Now if you prefer work with Markdown files you can add a `--m` in the end of the command and will be created one file like `F-d-Y-title-of-the-my-post.md`.
