### PR TITLE
Added sitemap generation

### DIFF
--- a/src/SiteBuilder.php
+++ b/src/SiteBuilder.php
@@ -124,6 +124,7 @@ class SiteBuilder
             $this->handleBlogPostsFiles($blogPostsFiles);
             $this->buildBlogPagination();
             $this->buildRSSFeed();
+            $this->buildSitemap();
         }
     }
 
@@ -260,6 +261,22 @@ class SiteBuilder
     private function buildRSSFeed()
     {
         $builder = new RSSFeedBuilder(
+            $this->filesystem,
+            $this->viewFactory,
+            $this->viewsData
+        );
+
+        $builder->build();
+    }
+
+    /**
+     * Build the blog sitemap.
+     *
+     * @return void
+     */
+    private function buildSitemap()
+    {
+        $builder = new SitemapBuilder(
             $this->filesystem,
             $this->viewFactory,
             $this->viewsData

--- a/src/SitemapBuilder.php
+++ b/src/SitemapBuilder.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Katana;
+
+use Symfony\Component\Finder\SplFileInfo;
+use Katana\Filesystem;
+use Illuminate\View\Factory;
+use Illuminate\Support\Str;
+
+class SitemapBuilder
+{
+    private $filesystem;
+    private $viewFactory;
+    private $viewsData;
+
+    /**
+     * SitemapBuilder constructor.
+     *
+     * @param Filesystem $filesystem
+     * @param Factory $viewFactory
+     * @param array $viewsData
+     */
+    public function __construct(Filesystem $filesystem, Factory $viewFactory, array $viewsData)
+    {
+        $this->filesystem = $filesystem;
+        $this->viewFactory = $viewFactory;
+        $this->viewsData = $viewsData;
+    }
+
+    /**
+     * Build blog Sitemap file.
+     *
+     * @return void
+     */
+    public function build()
+    {
+        if (! $view = $this->getSitemapView()) {
+            return;
+        }
+
+        // Filter out some compiled sites for generating the sitemap.
+        $files = array_filter($this->filesystem->allFiles(KATANA_PUBLIC_DIR), function (SplFileInfo $file) {
+            $path = $file->getRelativePathName();
+            return Str::endsWith($path, '.html') && !Str::startsWith($path, 'blog-page') && !Str::startsWith($path, 'sitemap') && !Str::startsWith($path, 'feed');
+        });
+
+        // Only get the relative path of the files.
+        $sites = array_map(function($site) {
+          return str_replace('index.html', '', $site->getRelativePathName());
+        }, $files);
+
+        $pageContent = $this->viewFactory->make($view, $this->viewsData + ['sites' => (array)$sites])->render();
+
+        $this->filesystem->put(
+            sprintf('%s/%s', KATANA_PUBLIC_DIR, 'sitemap.xml'),
+            $pageContent
+        );
+    }
+
+    /**
+     * Get the name of the view to be used for generating the Sitemap.
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    private function getSitemapView()
+    {
+        if (! isset($this->viewsData['sitemapView']) || ! @$this->viewsData['sitemapView']) {
+            return null;
+        }
+
+        if (! $this->viewFactory->exists($this->viewsData['sitemapView'])) {
+            throw new \Exception(sprintf('The "%s" view is not found. Make sure the rssFeedView configuration key is correct.', $this->viewsData['rssFeedView']));
+        }
+
+        return $this->viewsData['sitemapView'];
+    }
+}


### PR DESCRIPTION
Big 👍 for your work.

We think it could be helpful to have a basic sitemap so we adapted the code from the RSS feed builder.

User needs to set `sitemapView` in `config.php` and a sitemap blade template.

Basic example:
```
<?xml version="1.0" encoding="UTF-8" ?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  @foreach($sites as $site)
  <url>
    <loc>{{ $siteUrl }}{{ $site }}</loc>
  </url>
  @endforeach
</urlset>
```

