### PR TITLE
Create Serve Command

### DIFF
--- a/src/Commands/ServeCommand.php
+++ b/src/Commands/ServeCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Katana\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ServeCommand extends Command
+{
+	/**
+     * Configure the command.
+     *
+     * @return void
+     */
+	protected function configure()
+	{
+		$this->setName('serve')
+            ->setDescription('Serve local site with php built-in server.')
+            ->addOption(
+            	'port',
+            	'p',
+            	InputOption::VALUE_REQUIRED,
+            	'What port should we use?',
+                8000
+        	);
+	}
+
+	/**
+     * Execute the command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return void
+     */
+	protected function execute(InputInterface $input, OutputInterface $output)
+	{
+		$port = $input->getOption('port');
+
+		$output->writeln("<info>Started listening on http://localhost:{$port}</info>");
+		passthru("php -S localhost:{$port} -t public");
+	}
+}


### PR DESCRIPTION
This is a new command for katana project as "php katana serve" it will serve local site with php built-in server with option to configure port as -p "custom port" | --port "custom port" .

I find this is very efficient approach which is missing in current katana components which will make the katana complete at this stage like the laravel does.